### PR TITLE
Fix installation instructions for Scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ resolvers += "Sonatype Releases" at "https://oss.sonatype.org/content/repositori
 
 You can use Scrypto in your sbt project by simply adding the following dependency to your build file:
 ```scala
+// For Scala 2.12
 libraryDependencies += "org.consensusresearch" %% "scrypto" % "1.2.0"
+// For Scala 2.11
+libraryDependencies += "org.consensusresearch" %% "scrypto" % "1.2.0-RC3"
 ```
 
 ### Hash functions


### PR DESCRIPTION
Until Scrypto 1.2.0 for Scala 2.11 is released fix the Readme to show that Scrypto 1.2.0-RC3 should be used with Scala 2.11