### PR TITLE
Optype

### DIFF
--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLProver.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLProver.scala
@@ -103,14 +103,10 @@ class BatchAVLProver[HF <: ThreadUnsafeHash](val keyLength: Int = 32,
 
   def digest: Array[Byte] = digest(topNode)
 
-  /**
-    * The tree has been modified without
-    */
-  def modified = !oldTopNode.label.sameElements(topNode.label)
 
-  def performOneOperation[M <: Operation](modification: M): Try[Option[AVLValue]] = Try {
+  def performOneOperation[M <: Operation](operation: M): Try[Option[AVLValue]] = Try {
     replayIndex = directionsBitLength
-    returnResultOfOneModification(modification, topNode) match {
+    returnResultOfOneOperation(operation, topNode) match {
       case Success(n) =>
         topNode = n._1.asInstanceOf[ProverNodes]
         n._2

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
@@ -143,9 +143,9 @@ class BatchAVLVerifier[HF <: ThreadUnsafeHash](startingDigest: Array[Byte],
 
   private var topNode: Option[VerifierNodes] = reconstructedTree
 
-  def performOneOperation[M <: Operation](modification: M): Try[Option[AVLValue]] = Try {
+  def performOneOperation[M <: Operation](operation: M): Try[Option[AVLValue]] = Try {
     replayIndex = directionsIndex
-    val operationResult = returnResultOfOneModification(modification, topNode.get)
+    val operationResult = returnResultOfOneOperation(operation, topNode.get)
     topNode = operationResult.map(s => Some(s._1.asInstanceOf[VerifierNodes])).getOrElse(None)
     // If TopNode was already None, then the line above should fail and return None
     operationResult.get._2

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
@@ -41,7 +41,8 @@ class BatchAVLVerifier[HF <: ThreadUnsafeHash](startingDigest: Array[Byte],
   }
 
   protected def keyMatchesLeaf(key: AVLKey, r: Leaf): Boolean = {
-    val c = ByteArray.compare(key, r.key).ensuring(_ >= 0)
+    val c = ByteArray.compare(key, r.key)
+    require(c>=0)
     if (c == 0) {
       true
     } else {


### PR DESCRIPTION
Most changes are minor, but one has a security implication: .ensuring should not be used in verifier code, because it can be elided by compiler flag -Xdisable-assertions