### PR TITLE
Use the provided APP_DIR in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM aa8y/sbt:1.0
 
-ARG APP_DIR=/scrypto_app
-
-USER root
-RUN rm -rf $APP_DIR
-RUN mkdir $APP_DIR
-RUN chown -R docker:docker $APP_DIR
 WORKDIR $APP_DIR
 
 # Cache the SBT JARs in a layer.


### PR DESCRIPTION
The aa8y/sbt image provides an APP_DIR location which is `/usr/src/app`. This is provided through it's base image `aa8y/core` (See: https://github.com/aa8y/docker-core/blob/master/jdk8/Dockerfile). This PR changes the `Dockerfile` to use that directory. This is to prevent the build from breaking in the future.