### PR TITLE
Base58 improvements

### DIFF
--- a/src/main/scala/scorex/crypto/encode/Base58.scala
+++ b/src/main/scala/scorex/crypto/encode/Base58.scala
@@ -7,6 +7,12 @@ import scala.util.Try
   */
 object Base58 {
   private val Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+  private val DecodeTable = Array(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -1, -1, -1, -1, -1, -1, 9, 10, 11, 12, 13, 14, 15, 16, -1, 17, 18, 19, 20, 21, -1,
+    22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, -1, -1, -1, -1, -1, -1, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, -1,
+    44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57
+  )
+
   private val Base = BigInt(58)
 
   def encode(input: Array[Byte]): String = {
@@ -50,9 +56,13 @@ object Base58 {
 
   private def decodeToBigInteger(input: String): BigInt =
   // Work backwards through the string.
-    input.foldRight((BigInt(0), input.length - 1)) { case (ch, (bi, i)) =>
-      val alphaIndex = Alphabet.indexOf(ch)
-        .ensuring(_ != -1, "Wrong char in Base58 string")
-      (bi + BigInt(alphaIndex) * Base.pow(input.length - 1 - i), i - 1)
+    input.foldRight((BigInt(0), BigInt(1))) { case (ch, (bi, k)) =>
+      val alphaIndex = toBase58(ch).ensuring(_ != -1, "Wrong char in Base58 string")
+      (bi + BigInt(alphaIndex) * k, k * Base)
     }._1
+
+  private def toBase58(c: Char): Int = {
+    val x = c.toInt
+    if (x < 49) -1 else if (x <= 122) DecodeTable(x - 49) else -1
+  }
 }

--- a/src/main/scala/scorex/crypto/encode/Base58.scala
+++ b/src/main/scala/scorex/crypto/encode/Base58.scala
@@ -14,9 +14,9 @@ object Base58 {
     val s = new StringBuilder()
     if (bi > 0) {
       while (bi >= Base) {
-        val mod = bi.mod(Base)
+        val (newBi, mod) = bi /% Base
         s.insert(0, Alphabet.charAt(mod.intValue()))
-        bi = (bi - mod) / Base
+        bi = newBi
       }
       s.insert(0, Alphabet.charAt(bi.intValue()))
     }

--- a/src/test/scala/scorex/crypto/encode/Base58Specification.scala
+++ b/src/test/scala/scorex/crypto/encode/Base58Specification.scala
@@ -1,5 +1,8 @@
 package scorex.crypto.encode
 
+import java.util
+
+import org.scalacheck.Arbitrary
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
 
@@ -31,5 +34,13 @@ with Matchers {
   property("base58 sample") {
     val b58 = "1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i"
     Base58.encode(Base58.decode(b58).get) shouldBe b58
+  }
+
+  property("Base58 round trip") {
+    forAll(Arbitrary.arbString.arbitrary.filter(_.nonEmpty)) { origStr =>
+      val origBytes = origStr.getBytes()
+      val decodedBytes = Base58.decode(Base58.encode(origBytes)).get
+      util.Arrays.equals(origBytes, decodedBytes)
+    }
   }
 }


### PR DESCRIPTION
Base58.encode benchmark
---------------------------

Code:
```scala
class Base58EncodeBenchmark {
  @Benchmark
  def encodeImproved(bh: Blackhole): Unit = {
    bh.consume {
      (1 to 1000)
        .view
        .map { _ =>
          Array.fill(500)(Random.nextInt().toByte)
        }
        .map(Base58.encodeImproved)
        .force
    }
  }

  @Benchmark
  def encodeDefault(bh: Blackhole): Unit = {
    bh.consume {
      (1 to 1000)
        .view
        .map { _ =>
          Array.fill(500)(Random.nextInt().toByte)
        }
        .map(Base58.encodeDefault)
        .force
    }
  }
}
```

Result:
```
// jmh:run -prof jmh.extras.JFR -t1 -f 1 -wi 10 -i 20 .*Base58EncodeBenchmark.*
[info] Benchmark                                  Mode  Cnt  Score   Error  Units
[info] Base58EncodeBenchmark.encodeDefault       thrpt   20  0.681 ± 0.007  ops/s
[info] Base58EncodeBenchmark.encodeImproved      thrpt   20  1.338 ± 0.009  ops/s
```

Base58.decode benchmark
---------------------------

Code:
```scala
class Base58DecodeBenchmark {

  @Benchmark
  def decodeImproved(state: BenchmarkState, bh: Blackhole): Unit = {
    bh.consume {
      state.xs.map(Base58.decodeImproved)
    }
  }

  @Benchmark
  def decodeDefault(state: BenchmarkState, bh: Blackhole): Unit = {
    bh.consume {
      state.xs.map(Base58.decodeDefault)
    }
  }

}

object Base58DecodeBenchmark {

  @State(Scope.Benchmark)
  class BenchmarkState {
    val xs: Seq[String] = (1 to 1000)
      .view
      .map { _ => Array.fill(500)(Random.nextInt().toByte) }
      .map(Base58.encodeDefault)
      .force
  }

}
```

Result:
```
// jmh:run -prof jmh.extras.JFR -t1 -f 1 -wi 10 -i 20 .*Base58DecodeBenchmark.*
[info] Benchmark                                  Mode  Cnt  Score   Error  Units
[info] Base58DecodeBenchmark.decodeDefault       thrpt   20  0.734 ± 0.129  ops/s
[info] Base58DecodeBenchmark.decodeImproved      thrpt   20  4.160 ± 0.048  ops/s
```
