### PR TITLE
Allowed empty string in Base58.decode()

### DIFF
--- a/src/main/scala/scorex/crypto/encode/Base58.scala
+++ b/src/main/scala/scorex/crypto/encode/Base58.scala
@@ -33,8 +33,6 @@ object Base58 extends BytesEncoder {
   }
 
   override def decode(input: String): Try[Array[Byte]] = Try {
-    require(input.length > 0, "Empty input for Base58.decode")
-
     val decoded = decodeToBigInteger(input)
 
     val bytes: Array[Byte] = if (decoded == BigInt(0)) Array.empty else decoded.toByteArray

--- a/src/test/scala/scorex/crypto/encode/Base58Specification.scala
+++ b/src/test/scala/scorex/crypto/encode/Base58Specification.scala
@@ -31,4 +31,10 @@ class Base58Specification extends EncoderSpecification {
       util.Arrays.equals(origBytes, decodedBytes)
     }
   }
+
+  property("empty string roundtrip") {
+    import Array.emptyByteArray
+    Base58.encode(emptyByteArray) shouldBe ""
+    Base58.decode("").get shouldBe emptyByteArray
+  }
 }


### PR DESCRIPTION
Because Base58.encode() can return empty string, I believe it's natural for Base58.decode() to accept it. The fix is just to remove a requirement.