### PR TITLE
More efficient base16 encoding/decoding

### DIFF
--- a/src/main/scala/scorex/crypto/encode/Base16.scala
+++ b/src/main/scala/scorex/crypto/encode/Base16.scala
@@ -1,15 +1,71 @@
 package scorex.crypto.encode
 
+import java.io.IOException
+
 import org.bouncycastle.util.encoders.Hex
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object Base16 extends BytesEncoder {
 
   override val Alphabet: String = "0123456789abcdefABCDEF"
+  private val hexArray = "0123456789abcdef".toCharArray
 
-  def encode(input: Array[Byte]): String = Hex.toHexString(input)
+  private val hexIndex: Array[Byte] = {
+     var index = Array.fill[Byte](128)(0xff.toByte)
+     hexArray.zipWithIndex.foreach { case (c, i) =>
+        index(c) = i.toByte
+     }
+     "abcdef".toCharArray.foreach{ c =>
+       index(c.toUpper) = index(c)
+     }
+    index
+  }
 
-  def decode(input: String): Try[Array[Byte]] = Try(Hex.decode(input))
+  def encode(input: Array[Byte]): String = {
+    val buf = new Array[Char](input.length * 2)
+    var j = 0
+    while (j < input.length) {
+      val v = input(j) & 0xFF
+      buf(j * 2) = hexArray(v >>> 4)
+      buf(j * 2 + 1)= hexArray(v & 0x0F)
+      j += 1
+    }
+    new String(buf)
+  }
 
+  def decode(input: String): Try[Array[Byte]] = {
+    var (isError, errorMsg) = if (input.length % 2 == 0) {
+      (false, "")
+    } else {
+      (true, s"invalid length ${input.length} of Hex data")
+    }
+
+    val out = Array.ofDim[Byte](input.length / 2)
+    var j = 0
+    while (j < input.length && !isError) {
+      val c1 = input(j)
+      val c2 = input(j + 1)
+      if (c1 > 0 && c1 < 127 && c2 > 0 && c2 < 127) {
+        val b1 = hexIndex(c1)
+        val b2 = hexIndex(c2)
+        if ((b1 | b2) < 0) {
+          isError = true
+          errorMsg = "invalid characters encountered in Hex data"
+        } else {
+          out(j / 2) = ((b1 << 4) | b2).toByte
+        }
+      } else {
+        isError = true
+        errorMsg = "invalid characters encountered in Hex data"
+      }
+      j += 2
+    }
+
+    if (!isError) {
+      Success(out)
+    } else {
+      Failure(new IOException(errorMsg))
+    }
+  }
 }


### PR DESCRIPTION
Benchmarks before changes:

[info] Result "scorex.benchmarks.Base16Benchmark.encode": 
[info]   146,520 ±(99.9%) 3,077 ops/s [Average] 
[info]   (min, avg, max) = (130,080, 146,520, 163,870), stdev = 13,028 
[info]   CI (99.9%): [143,443, 149,597] (assumes normal distribution) 
[info] # Run complete. Total time: 00:13:42 
[info] Benchmark                Mode  Cnt    Score   Error  Units 
[info] Base16Benchmark.decode  thrpt  200  208,211 ± 0,935  ops/s 
[info] Base16Benchmark.encode  thrpt  200  146,520 ± 3,077  ops/s

After changes:

[info] Result "scorex.benchmarks.Base16Benchmark.encode": 
[info]   652,414 ±(99.9%) 2,127 ops/s [Average] 
[info]   (min, avg, max) = (544,154, 652,414, 659,745), stdev = 9,005 
[info]   CI (99.9%): [650,288, 654,541] (assumes normal distribution) 
[info] # Run complete. Total time: 00:13:36 
[info] Benchmark                Mode  Cnt    Score   Error  Units 
[info] Base16Benchmark.decode  thrpt  200  562,127 ± 0,909  ops/s 
[info] Base16Benchmark.encode  thrpt  200  652,414 ± 2,127  ops/s