### PR TITLE
Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: scala
 scala:
 - 2.12.10
 - 2.11.12
+- 2.13.1
 jdk:
 - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val scala211 = "2.11.12"
 lazy val scala213 = "2.13.1"
 
 crossScalaVersions := Seq(scala212, scala211, scala213)
-scalaVersion := scala212
+scalaVersion := scala213
 
 javacOptions ++=
   "-source" :: "1.8" ::

--- a/build.sbt
+++ b/build.sbt
@@ -7,12 +7,14 @@ description := "Cryptographic primitives for Scala"
 
 lazy val scala212 = "2.12.10"
 lazy val scala211 = "2.11.12"
-crossScalaVersions := Seq(scala212, scala211)
+lazy val scala213 = "2.13.1"
+
+crossScalaVersions := Seq(scala212, scala211, scala213)
 scalaVersion := scala212
 
 javacOptions ++=
-  "-source" :: "1.7" ::
-    "-target" :: "1.7" ::
+  "-source" :: "1.8" ::
+    "-target" :: "1.8" ::
     Nil
 
 lazy val commonSettings = Seq(
@@ -31,7 +33,7 @@ lazy val commonSettings = Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.rudogma" %% "supertagged" % "1.4",
+  "org.rudogma" %% "supertagged" % "1.5",
   "com.google.guava" % "guava" % "20.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "org.whispersystems" % "curve25519-java" % "0.5.0",
@@ -40,8 +42,10 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.+" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.13.+" % "test"
+  "org.scalatest" %% "scalatest" % "3.1.+" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.14.+" % Test,
+  // https://mvnrepository.com/artifact/org.scalatestplus/scalatestplus-scalacheck
+  "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test
 )
 
 publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "org.whispersystems" % "curve25519-java" % "0.5.0",
   "org.bouncycastle" % "bcprov-jdk15on" % "1.64",
-  "org.scorexfoundation" %% "scorex-util" % "0.1.6"
+  "org.scorexfoundation" %% "scorex-util" % "0.1.7"
 )
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.6
+sbt.version=1.2.8
 

--- a/src/main/scala/scorex/crypto/authds/TwoPartyDictionary.scala
+++ b/src/main/scala/scorex/crypto/authds/TwoPartyDictionary.scala
@@ -1,7 +1,7 @@
 package scorex.crypto.authds
 
 import scorex.crypto.authds.avltree.batch.Operation
-import scorex.utils.ScorexEncoding
+import scorex.util.ScorexEncoding
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/crypto/authds/TwoPartyProofElement.scala
+++ b/src/main/scala/scorex/crypto/authds/TwoPartyProofElement.scala
@@ -1,7 +1,7 @@
 package scorex.crypto.authds
 
 import scorex.crypto.authds.legacy.treap.Level
-import scorex.utils.ScorexEncoding
+import scorex.util.ScorexEncoding
 
 trait TwoPartyProofElement extends ScorexEncoding {
   val bytes: Array[Byte]

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLProver.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLProver.scala
@@ -267,7 +267,7 @@ class BatchAVLProver[D <: Digest, HF <: CryptographicHash[D]](val keyLength: Int
      *   that contains only this info)
      * - Condense the sequence of values if they are mostly not randomly distributed
      * */
-    def packTree(rNode: ProverNodes[D]) {
+    def packTree(rNode: ProverNodes[D]): Unit = {
       // Post order traversal to pack up the tree
       if (!rNode.visited) {
         packagedTree += LabelInPackagedProof
@@ -357,21 +357,21 @@ class BatchAVLProver[D <: Digest, HF <: CryptographicHash[D]](val keyLength: Int
     * @return Random leaf from the tree that is not positive or negative infinity
     */
   def randomWalk(rand: Random = new Random): Option[(ADKey, ADValue)] = {
-    def internalNodeFn(r: InternalProverNode[D], dummy: Unit.type) =
+    def internalNodeFn(r: InternalProverNode[D], dummy: Unit): (ProverNodes[D], Unit) =
       rand.nextBoolean() match {
         case true =>
-          (r.right, Unit)
+          (r.right, ())
         case false =>
-          (r.left, Unit)
+          (r.left, ())
       }
 
-    def leafFn(leaf: ProverLeaf[D], dummy: Unit.type): Option[(ADKey, ADValue)] = {
+    def leafFn(leaf: ProverLeaf[D], dummy: Unit): Option[(ADKey, ADValue)] = {
       if (leaf.key sameElements PositiveInfinityKey) None
       else if (leaf.key sameElements NegativeInfinityKey) None
       else Some(leaf.key -> leaf.value)
     }
 
-    treeWalk(internalNodeFn, leafFn, Unit)
+    treeWalk(internalNodeFn, leafFn, ())
   }
 
   /**

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLProver.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLProver.scala
@@ -29,7 +29,7 @@ class BatchAVLProver[D <: Digest, HF <: CryptographicHash[D]](val keyLength: Int
                                                              (implicit val hf: HF = Blake2b256)
   extends AuthenticatedTreeOps[D] with ToStringHelper with ScorexLogging {
 
-  protected val labelLength = hf.DigestSize
+  protected val labelLength: Int = hf.DigestSize
 
   private[batch] var topNode: ProverNodes[D] = oldRootAndHeight.map(_._1).getOrElse({
     val t = new ProverLeaf(NegativeInfinityKey,
@@ -230,7 +230,7 @@ class BatchAVLProver[D <: Digest, HF <: CryptographicHash[D]](val keyLength: Int
       }
     }
 
-    loop(topNode, false)
+    loop(topNode, keyFound = false)
   }
 
   /**
@@ -442,7 +442,7 @@ class BatchAVLProver[D <: Digest, HF <: CryptographicHash[D]](val keyLength: Int
     var fail: Boolean = false
 
     def checkTreeHelper(rNode: ProverNodes[D]): (ProverLeaf[D], ProverLeaf[D], Int) = {
-      def myRequire(t: Boolean, s: String) = {
+      def myRequire(t: Boolean, s: String): Unit = {
         if (!t) {
           var x = rNode.key(0).toInt
           if (x < 0) x = x + 256

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
@@ -5,7 +5,6 @@ import scorex.crypto.authds._
 import scorex.crypto.hash._
 import scorex.utils.ByteArray
 
-import scala.collection.mutable
 import scala.util.{Failure, Try}
 
 /**
@@ -33,7 +32,7 @@ class BatchAVLVerifier[D <: Digest, HF <: CryptographicHash[D]](startingDigest: 
 
   override val collectChangedNodes: Boolean = false
 
-  protected val labelLength = hf.DigestSize
+  protected val labelLength: Int = hf.DigestSize
 
   /**
     * Returns Some[the current digest of the authenticated data structure],
@@ -169,8 +168,7 @@ class BatchAVLVerifier[D <: Digest, HF <: CryptographicHash[D]](startingDigest: 
     // Now reconstruct the tree from the proof, which has the post order traversal
     // of the tree
     var numNodes = 0
-    var s = List.empty[VerifierNodes[D]]
-
+    var s = List.empty[VerifierNodes[D]] // Nodes and depths
     var i = 0
     var previousLeaf: Option[Leaf[D]] = None
     while (proof(i) != EndOfTreeInPackagedProof) {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/Operation.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/Operation.scala
@@ -2,7 +2,7 @@ package scorex.crypto.authds.avltree.batch
 
 import com.google.common.primitives.Longs
 import scorex.crypto.authds.{ADKey, ADValue}
-import scorex.utils.ScorexEncoding
+import scorex.util.ScorexEncoding
 
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/ToStringHelper.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/ToStringHelper.scala
@@ -1,6 +1,6 @@
 package scorex.crypto.authds.avltree.batch
 
-import scorex.utils.ScorexEncoding
+import scorex.util.ScorexEncoding
 
 trait ToStringHelper extends ScorexEncoding {
   //Needed for debug (toString) only

--- a/src/main/scala/scorex/crypto/authds/legacy/avltree/AVLTree.scala
+++ b/src/main/scala/scorex/crypto/authds/legacy/avltree/AVLTree.scala
@@ -263,6 +263,6 @@ class AVLTree[HF <: CryptographicHash[_ <: Digest]](keyLength: Int,
 
     val (newTopNode, changeHappened, childHeightIncreased) = modifyHelper(topNode, foundAbove = false)
     if (changeHappened) topNode = newTopNode
-    AVLModifyProof(key, proofStream)
+    AVLModifyProof(key, proofStream.toSeq) //toSeq required for 2.13
   }
 }

--- a/src/main/scala/scorex/crypto/authds/legacy/treap/Treap.scala
+++ b/src/main/scala/scorex/crypto/authds/legacy/treap/Treap.scala
@@ -147,6 +147,6 @@ class Treap[HF <: CryptographicHash[_ <: Digest]](rootOpt: Option[Leaf] = None)
 
     val (newTopNode: ProverNodes, changeHappened: Boolean) = modifyHelper(topNode, foundAbove = false)
     if (changeHappened) topNode = newTopNode
-    TreapModifyProof(key, proofStream)
+    TreapModifyProof(key, proofStream.toSeq) // .toSeq required for 2.13
   }
 }

--- a/src/main/scala/scorex/crypto/authds/merkle/MerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/MerkleProof.scala
@@ -2,7 +2,7 @@ package scorex.crypto.authds.merkle
 
 import scorex.crypto.authds.{LeafData, Side}
 import scorex.crypto.hash.{CryptographicHash, Digest}
-import scorex.utils.ScorexEncoding
+import scorex.util.ScorexEncoding
 
 /**
   * Proof is given leaf data, leaf hash sibling and also siblings for parent nodes. Using this data, it is possible to

--- a/src/main/scala/scorex/crypto/authds/merkle/Node.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/Node.scala
@@ -2,7 +2,7 @@ package scorex.crypto.authds.merkle
 
 import scorex.crypto.authds.LeafData
 import scorex.crypto.hash._
-import scorex.utils.ScorexEncoding
+import scorex.util.ScorexEncoding
 
 trait Node[D <: Digest] extends ScorexEncoding {
   def hash: D

--- a/src/main/scala/scorex/crypto/authds/merkle/sparse/Node.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/sparse/Node.scala
@@ -1,7 +1,7 @@
 package scorex.crypto.authds.merkle.sparse
 
 import scorex.crypto.authds.LeafData
-import scorex.crypto.encode.Base16
+import scorex.util.encode.Base16
 import scorex.crypto.hash._
 
 trait Node[D <: Digest] {

--- a/src/test/scala/scorex/crypto/TestingCommons.scala
+++ b/src/test/scala/scorex/crypto/TestingCommons.scala
@@ -3,7 +3,7 @@ package scorex.crypto
 import java.io.File
 
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random
 

--- a/src/test/scala/scorex/crypto/authds/avltree/AVLDeleteSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/AVLDeleteSpecification.scala
@@ -1,12 +1,13 @@
 package scorex.crypto.authds.avltree
 
-import org.scalatest.PropSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.authds.avltree.batch._
 import scorex.crypto.authds.{ADKey, ADValue, TwoPartyTests}
 import scorex.crypto.hash.{Blake2b256, Digest32, Sha256}
 
-class AVLDeleteSpecification extends PropSpec with GeneratorDrivenPropertyChecks with TwoPartyTests {
+class AVLDeleteSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with TwoPartyTests {
 
   val KL = 26
   val VL = 8

--- a/src/test/scala/scorex/crypto/authds/avltree/AVLTreeSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/AVLTreeSpecification.scala
@@ -1,14 +1,14 @@
 package scorex.crypto.authds.avltree
 
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.PropSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.authds.avltree.batch.{Insert, InsertOrUpdate, Lookup, Update}
 import scorex.crypto.authds.legacy.avltree.{AVLModifyProof, AVLTree}
 import scorex.crypto.authds.{ADKey, ADValue, TwoPartyTests}
 import scorex.crypto.hash.Sha256
 
-class AVLTreeSpecification extends PropSpec with GeneratorDrivenPropertyChecks with TwoPartyTests {
+class AVLTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with TwoPartyTests {
 
   val KL = 26
   val VL = 8

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/AVLBatchSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/AVLBatchSpecification.scala
@@ -2,19 +2,18 @@ package scorex.crypto.authds.avltree.batch
 
 import com.google.common.primitives.Longs
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.PropSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import scorex.crypto.authds.avltree.batch.BatchingPlayground.{D, HF, generateProver, time}
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.authds.legacy.avltree.AVLTree
 import scorex.crypto.authds._
-import scorex.crypto.encode.{Base16, Base58}
-import scorex.crypto.hash.{Blake2b256, _}
+import scorex.util.encode.{Base16, Base58}
+import scorex.crypto.hash._
 import scorex.utils.{ByteArray, Random}
 
 import scala.util.Random.{nextInt => randomInt}
 import scala.util.{Failure, Try}
 
-class AVLBatchSpecification extends PropSpec with GeneratorDrivenPropertyChecks with TwoPartyTests
+class AVLBatchSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with TwoPartyTests
   with BatchTestingHelpers {
 
   property("return removed leafs and internal nodes for small tree") {

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/AVLBatchStatefulSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/AVLBatchStatefulSpecification.scala
@@ -3,14 +3,14 @@ package scorex.crypto.authds.avltree.batch
 import com.google.common.primitives.Longs
 import org.scalacheck.commands.Commands
 import org.scalacheck.{Gen, Prop}
-import org.scalatest.PropSpec
+import org.scalatest.propspec.AnyPropSpec
 import scorex.crypto.authds._
 import scorex.crypto.hash.{Blake2b256, Digest32}
 import scorex.utils.{Random => RandomBytes}
 
 import scala.util.{Failure, Random, Success, Try}
 
-class AVLBatchStatefulSpecification extends PropSpec {
+class AVLBatchStatefulSpecification extends AnyPropSpec {
 
   property("BatchAVLProver: prove and verify") {
     AVLCommands.property().check

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/BatchTesting.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/BatchTesting.scala
@@ -32,7 +32,7 @@ class LegacyProver(tree: AVLTree[_]) {
         case Failure(e) => throw BatchFailure(e, m)
       }
     }
-    BatchSuccessSimple(aggregatedProofs)
+    BatchSuccessSimple(aggregatedProofs.toSeq)
   } match {
     case Success(p) => p
     case Failure(e: BatchFailure) => e

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/BatchTestingHelpers.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/BatchTestingHelpers.scala
@@ -1,6 +1,6 @@
 package scorex.crypto.authds.avltree.batch
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import scorex.crypto.authds.{ADKey, ADValue}
 import scorex.crypto.hash.{Blake2b256, Digest32}
 import scorex.utils.Random

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/BatchingPlayground.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/BatchingPlayground.scala
@@ -1,7 +1,7 @@
 package scorex.crypto.authds.avltree.batch
 
 import com.google.common.primitives.Longs
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import scorex.crypto.authds.legacy.avltree.{AVLModifyProof, AVLTree}
 import scorex.crypto.authds.{ADDigest, ADKey, ADValue}
 import scorex.crypto.hash.{Blake2b256, Digest32, Sha256}

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
@@ -1,14 +1,14 @@
 package scorex.crypto.authds.avltree.batch.serialization
 
 import org.scalacheck.{Gen, Shrink}
-import org.scalatest.PropSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.authds.avltree.batch._
 import scorex.crypto.authds.{ADKey, ADValue, TwoPartyTests}
 import scorex.crypto.hash.{Blake2b256, _}
 import scorex.utils.Random
 
-class AVLBatchSerializationSpecification extends PropSpec with GeneratorDrivenPropertyChecks with TwoPartyTests {
+class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with TwoPartyTests {
 
   val InitialTreeSize = 1000
   val KL = 26

--- a/src/test/scala/scorex/crypto/authds/legacy/treap/TreapSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/legacy/treap/TreapSpecification.scala
@@ -1,15 +1,15 @@
 package scorex.crypto.authds.legacy.treap
-
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.authds._
 import scorex.crypto.authds.avltree.batch.InsertOrUpdate
 import scorex.crypto.authds.legacy.treap.Constants._
 import scorex.crypto.hash.Blake2b256
 
 
-class TreapSpecification extends PropSpec with GeneratorDrivenPropertyChecks with Matchers with TwoPartyTests {
+class TreapSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers with TwoPartyTests {
 
 
   def validKey(key: ADKey): Boolean = key.length > 1 && key.length < MaxKeySize

--- a/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
@@ -1,12 +1,14 @@
 package scorex.crypto.authds.merkle
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.TestingCommons
 import scorex.crypto.authds.LeafData
-import scorex.crypto.hash.{Digest32, Keccak256}
+import scorex.crypto.hash.Keccak256
 
-class MerkleTreeSpecification extends PropSpec with GeneratorDrivenPropertyChecks with Matchers with TestingCommons {
+class MerkleTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers with TestingCommons {
   implicit val hf = Keccak256
 
   private val LeafSize = 32

--- a/src/test/scala/scorex/crypto/hash/Blake2bUnsafeSpecification.scala
+++ b/src/test/scala/scorex/crypto/hash/Blake2bUnsafeSpecification.scala
@@ -1,11 +1,11 @@
 package scorex.crypto.hash
 
-import org.scalatest.{Matchers, PropSpec}
-import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class Blake2bUnsafeSpecification extends PropSpec
-with PropertyChecks
-with GeneratorDrivenPropertyChecks
+class Blake2bUnsafeSpecification extends AnyPropSpec
+with ScalaCheckDrivenPropertyChecks
 with Matchers {
 
   val unsafeHash = new Blake2b256Unsafe

--- a/src/test/scala/scorex/crypto/hash/HashTest.scala
+++ b/src/test/scala/scorex/crypto/hash/HashTest.scala
@@ -1,16 +1,17 @@
 package scorex.crypto.hash
 
-import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Matchers, PropSpec}
-import scorex.crypto.encode.Base16
+
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import scorex.util.encode.Base16
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-trait HashTest extends PropSpec
-  with PropertyChecks
-  with GeneratorDrivenPropertyChecks
+trait HashTest extends AnyPropSpec
+  with ScalaCheckDrivenPropertyChecks
   with Matchers {
   val emptyBytes: Array[Byte] = Array.empty
 

--- a/src/test/scala/scorex/crypto/signing/SigningFunctionsSpecification.scala
+++ b/src/test/scala/scorex/crypto/signing/SigningFunctionsSpecification.scala
@@ -1,14 +1,15 @@
 package scorex.crypto.signing
 
-import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Matchers, PropSpec}
-import scorex.crypto.encode.Base16
+
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import scorex.util.encode.Base16
 import scorex.crypto.signatures.{Curve25519, PrivateKey}
 
 
-class SigningFunctionsSpecification extends PropSpec
-  with PropertyChecks
-  with GeneratorDrivenPropertyChecks
+class SigningFunctionsSpecification extends AnyPropSpec
+  with ScalaCheckDrivenPropertyChecks
   with Matchers {
 
   property("signed message should be verifiable with appropriate public key") {


### PR DESCRIPTION
Based on #73 :

"
Will now cross compile to 2.13
Tests needed porting
Replaced Stack with List in BatchAVLVerifier as a result of compiler warning
Some compiler warnings need review
Depends on 2.13 cross compile for scorex-util being in place (which it isn't, but the PR is pending).

#72
"

This PR also updates scorex-utils dependency (to 0.1.7 which is 2.13 friendly)