### PR TITLE
Added logError method

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ Here are code examples for generating proofs and checking them. In this example 
   val op6 = Lookup(ADKey @@ key3)
   val op7 = Remove(ADKey @@ Array(5:Byte))
   val op8 = Remove(ADKey @@ key3)
-  prover.performOneOperation(op4) // Returns Try(Some(Longs.toByteArray(10)))
+  prover.performOneOperation(op4) // Returns Success(Some(Longs.toByteArray(10)))
   // Here we can, for example, perform prover.unauthenticatedLookup(key1) to get 50
   // without affecting the proof or anything else
   prover.performOneOperation(op5) // Returns Failure
-  prover.performOneOperation(op6) // Returns Try(Some(Longs.toByteArray(30)))
+  prover.performOneOperation(op6) // Returns Success(Some(Longs.toByteArray(30)))
   prover.performOneOperation(op7) // Returns Failure
-  prover.performOneOperation(op8) // Returns Try(Some(Longs.toByteArray(30)))
+  prover.performOneOperation(op8) // Returns Success(Some(Longs.toByteArray(30)))
   val proof2 = prover.generateProof() // Proof only for op4 and op6
   val digest2 = prover.digest
 ```
@@ -160,9 +160,9 @@ Here are code examples for generating proofs and checking them. In this example 
     case Some(d1) if d1.sameElements(digest1) =>
       //If digest1 from the prover is already trusted, then verification of the second batch can simply start here
       val verifier2 = new BatchAVLVerifier[Digest32, Blake2b256.type](d1, proof2, keyLength = 1, valueLengthOpt = Some(8), maxNumOperations = Some(3), maxDeletes = Some(1))
-      verifier2.performOneOperation(op4) // Returns Try(Some(Longs.toByteArray(10)))
-      verifier2.performOneOperation(op6) // Returns Try(Some(Longs.toByteArray(30)))
-      verifier2.performOneOperation(op8) // Returns Try(Some(Longs.toByteArray(30)))
+      verifier2.performOneOperation(op4) // Returns Success(Some(Longs.toByteArray(10)))
+      verifier2.performOneOperation(op6) // Returns Success(Some(Longs.toByteArray(30)))
+      verifier2.performOneOperation(op8) // Returns Success(Some(Longs.toByteArray(30)))
       verifier2.digest match {
         case Some(d2) if d2.sameElements(digest2) => println("first and second digest value and proofs are valid")
         case _ => println("second proof or announced digest NOT valid")

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchAVLVerifier.scala
@@ -30,6 +30,11 @@ class BatchAVLVerifier[D <: Digest, HF <: CryptographicHash[D]](startingDigest: 
                                                                (implicit hf: HF = Blake2b256)
   extends AuthenticatedTreeOps[D] with ToStringHelper {
 
+  /** Default implementation of error logging. */
+  protected def logError(t: Throwable) = {
+    t.printStackTrace()
+  }
+
   override val collectChangedNodes: Boolean = false
 
   protected val labelLength: Int = hf.DigestSize
@@ -220,7 +225,7 @@ class BatchAVLVerifier[D <: Digest, HF <: CryptographicHash[D]](startingDigest: 
     directionsIndex = (i + 1) * 8 // Directions start right after the packed tree, which we just finished
     Some(root)
   }.recoverWith { case e =>
-    e.printStackTrace()
+    logError(e)
     Failure(e)
   }.getOrElse(None)
 


### PR DESCRIPTION
The method will allow avoid bloat of system log in tests. 
Specifically to avoid this message "The job exceeded the maximum log length, and has been terminated."
[See](https://travis-ci.org/github/ScorexFoundation/sigmastate-interpreter/jobs/707412332#L56570)

It can be used like this then
```
new BatchAVLVerifier[Digest32, Blake2b256.type](
      treeData.digest, adProof,
      treeData.keyLength, treeData.valueLengthOpt) {
      /** Override default logging which outputs stack trace to the console. */
      override protected def logError(t: Throwable): Unit = {}
    }
```

Also minor fixes in README