### PR TITLE
Batch Merkle Proof

### DIFF
--- a/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
@@ -10,10 +10,26 @@ import scala.language.postfixOps
 case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Seq[(Digest, Side)])
                                         (implicit val hf: CryptographicHash[D]) extends ScorexEncoding {
 
+  /**
+    * Validate BatchMerkleProof against an expected root hash
+    *
+    * @param expectedRootHash - BatchMerkleProof should evaluate to this hash
+    * @return true or false (Boolean)
+    */
   def valid(expectedRootHash: Digest): Boolean = {
 
+    /**
+      * Recursive function to validate the multiproof
+      *
+      * @param a - leaf indices
+      * @param e - sorted pairs of (index, hash) of the leaves
+      * @param m - hashes of the multiproof
+      * @return true or false (Boolean)
+      */
     def loop(a: Seq[Int], e: Seq[(Int, Digest)], m: Seq[(Digest, Side)]): Seq[Digest] = {
 
+      // For each of the indices in A, take the index of its immediate neighbor
+      // Store the given element index and the neighboring index as a pair of indices
       val b = a
         .map(i => {
           if (i % 2 == 0) {
@@ -23,6 +39,7 @@ case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Se
           }
         })
 
+      // B will always have the same size as E
       assert(e.size == b.size);
 
       var a_new: Seq[Int] = Seq.empty
@@ -31,23 +48,34 @@ case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Se
 
       var i = 0
 
+      // assign generated hashes to a new E that will be used for the next iteration
       while (i < b.size) {
+
+        // check for duplicate index pairs inside b
         if (b.size > 1 && b.lift(i) == b.lift(i + 1)) {
+
+          // hash the corresponding values inside E with one another
           e_new = e_new :+ hf.prefixedHash(InternalNodePrefix, e.apply(i)._2 ++ e.apply(i + 1)._2)
           i += 2
         } else {
+
+          // hash the corresponding value inside E with the first hash inside M, taking note of the side
           if (m_new.head._2 == MerkleProof.LeftSide) {
             e_new = e_new :+ hf.prefixedHash(MerkleTree.InternalNodePrefix, m_new.head._1 ++ e.apply(i)._2)
           } else {
             e_new = e_new :+ hf.prefixedHash(MerkleTree.InternalNodePrefix, e.apply(i)._2 ++ m_new.head._1)
           }
+
+          // remove the used value from m
           m_new = m_new.drop(1)
           i += 1
         }
       }
 
+      //  Take all the even numbers from B_pruned, and divide them by two
       a_new = b.distinct.map(_._1 / 2)
 
+      // Repeat until the root of the tree is reached (M has no more elements)
       if (e_new.size > 1) {
         e_new = loop(a_new, a_new zip e_new, m_new)
       }

--- a/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
@@ -1,0 +1,59 @@
+package scorex.crypto.authds.merkle
+
+import scorex.crypto.authds.{LeafData, Side}
+import scorex.crypto.hash.{CryptographicHash, Digest}
+import scorex.util.ScorexEncoding
+
+import scala.language.postfixOps
+
+case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Seq[Digest])
+                                        (implicit val hf: CryptographicHash[D]) extends ScorexEncoding {
+
+  def valid(expectedRootHash: Digest, hashes: Seq[Leaf[D]]): Boolean = {
+
+    def loop(a: Seq[Int], e: Seq[(Int, Digest)], m: Seq[Digest]): Seq[Digest] = {
+
+      val b = a
+        .map(i => {
+          if (i % 2 == 0) {
+            (i, i + 1)
+          } else {
+            (i - 1, i)
+          }
+        })
+
+      assert(e.length == b.length);
+
+      var a_new: Seq[Int] = Seq.empty
+      var e_new: Seq[Digest] = Seq.empty
+      var m_new = m
+
+      var i = 0
+
+      while (i < b.size) {
+
+        if (b.size > 1 && b.apply(i) == b.apply(i + 1)) {
+          e_new = e_new :+ hf.getValue(hf.hash(e.apply(i)._2 ++ e.apply(i + 1)._2))
+          i += 2
+        } else {
+          e_new = e_new :+ hf.getValue(hf.hash(e.apply(i)._2 ++ m.head))
+          m_new = m_new.tail
+          i += 1
+        }
+      }
+
+      a_new = b.distinct.map(_._1 / 2)
+
+      if (m_new.nonEmpty) {
+        e_new = loop(a_new, a_new zip e_new, m_new)
+      }
+      assert(e_new.size == 1)
+      e_new
+    }
+
+    val e = indexes sortBy(_._1)
+
+    loop(indexes.map(_._1), e, proofs).head.sameElements(expectedRootHash)
+
+  }
+}

--- a/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
@@ -1,17 +1,18 @@
 package scorex.crypto.authds.merkle
 
-import scorex.crypto.authds.{LeafData, Side}
+import scorex.crypto.authds.Side
+import scorex.crypto.authds.merkle.MerkleTree.InternalNodePrefix
 import scorex.crypto.hash.{CryptographicHash, Digest}
 import scorex.util.ScorexEncoding
 
 import scala.language.postfixOps
 
-case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Seq[Digest])
+case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Seq[(Digest, Side)])
                                         (implicit val hf: CryptographicHash[D]) extends ScorexEncoding {
 
-  def valid(expectedRootHash: Digest, hashes: Seq[Leaf[D]]): Boolean = {
+  def valid(expectedRootHash: Digest): Boolean = {
 
-    def loop(a: Seq[Int], e: Seq[(Int, Digest)], m: Seq[Digest]): Seq[Digest] = {
+    def loop(a: Seq[Int], e: Seq[(Int, Digest)], m: Seq[(Digest, Side)]): Seq[Digest] = {
 
       val b = a
         .map(i => {
@@ -22,7 +23,7 @@ case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Se
           }
         })
 
-      assert(e.length == b.length);
+      assert(e.size == b.size);
 
       var a_new: Seq[Int] = Seq.empty
       var e_new: Seq[Digest] = Seq.empty
@@ -31,29 +32,29 @@ case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Se
       var i = 0
 
       while (i < b.size) {
-
-        if (b.size > 1 && b.apply(i) == b.apply(i + 1)) {
-          e_new = e_new :+ hf.getValue(hf.hash(e.apply(i)._2 ++ e.apply(i + 1)._2))
+        if (b.size > 1 && b.lift(i) == b.lift(i + 1)) {
+          e_new = e_new :+ hf.prefixedHash(InternalNodePrefix, e.apply(i)._2 ++ e.apply(i + 1)._2)
           i += 2
         } else {
-          e_new = e_new :+ hf.getValue(hf.hash(e.apply(i)._2 ++ m.head))
-          m_new = m_new.tail
+          if (m_new.head._2 == MerkleProof.LeftSide) {
+            e_new = e_new :+ hf.prefixedHash(MerkleTree.InternalNodePrefix, m_new.head._1 ++ e.apply(i)._2)
+          } else {
+            e_new = e_new :+ hf.prefixedHash(MerkleTree.InternalNodePrefix, e.apply(i)._2 ++ m_new.head._1)
+          }
+          m_new = m_new.drop(1)
           i += 1
         }
       }
 
       a_new = b.distinct.map(_._1 / 2)
 
-      if (m_new.nonEmpty) {
+      if (e_new.size > 1) {
         e_new = loop(a_new, a_new zip e_new, m_new)
       }
-      assert(e_new.size == 1)
       e_new
     }
 
     val e = indexes sortBy(_._1)
-
     loop(indexes.map(_._1), e, proofs).head.sameElements(expectedRootHash)
-
   }
 }

--- a/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
@@ -7,7 +7,14 @@ import scorex.util.ScorexEncoding
 
 import scala.language.postfixOps
 
-case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Seq[(Digest, Side)])
+  /**
+    * Implementation is based on Compact Merkle Multiproofs by Lum Ramabaja
+    * Retrieved from https://deepai.org/publication/compact-merkle-multiproofs
+    *
+    * @param indices - leaf indices used to build the proof
+    * @param proofs - hash and side of nodes in the proof
+    */
+case class BatchMerkleProof[D <: Digest](indices: Seq[(Int, Digest)], proofs: Seq[(Digest, Side)])
                                         (implicit val hf: CryptographicHash[D]) extends ScorexEncoding {
 
   /**
@@ -40,7 +47,7 @@ case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Se
         })
 
       // B will always have the same size as E
-      assert(e.size == b.size);
+      assert(e.size == b.size)
 
       var a_new: Seq[Int] = Seq.empty
       var e_new: Seq[Digest] = Seq.empty
@@ -76,13 +83,13 @@ case class BatchMerkleProof[D <: Digest](indexes: Seq[(Int, Digest)], proofs: Se
       a_new = b.distinct.map(_._1 / 2)
 
       // Repeat until the root of the tree is reached (M has no more elements)
-      if (e_new.size > 1) {
+      if (m_new.nonEmpty || e_new.size > 1) {
         e_new = loop(a_new, a_new zip e_new, m_new)
       }
       e_new
     }
 
-    val e = indexes sortBy(_._1)
-    loop(indexes.map(_._1), e, proofs).head.sameElements(expectedRootHash)
+    val e = indices sortBy(_._1)
+    loop(indices.map(_._1), e, proofs).head.sameElements(expectedRootHash)
   }
 }

--- a/src/main/scala/scorex/crypto/authds/merkle/MerkleTree.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/MerkleTree.scala
@@ -2,14 +2,13 @@ package scorex.crypto.authds.merkle
 
 import scorex.crypto.authds.merkle.MerkleTree.InternalNodePrefix
 import scorex.crypto.authds.{LeafData, Side}
-import scorex.crypto.hash._
+import scorex.crypto.hash.{Digest, _}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 
 case class MerkleTree[D <: Digest](topNode: Node[D],
-                                   elementsHashIndex: Map[mutable.WrappedArray.ofByte, Int],
-                                   hashes: Seq[Digest]) {
+                                   elementsHashIndex: Map[mutable.WrappedArray.ofByte, Int]) {
 
   lazy val rootHash: D = topNode.hash
   lazy val length: Int = elementsHashIndex.size
@@ -73,6 +72,7 @@ case class MerkleTree[D <: Digest](topNode: Node[D],
       }
       m
     }
+    val hashes: Seq[Digest] = elementsHashIndex.toSeq.sortBy(_._2).map(_._1.toArray.asInstanceOf[Digest])
     val multiproof = loop(indexes, hashes)
     Some(BatchMerkleProof(indexes zip (indexes map hashes.apply), multiproof))
   }
@@ -123,7 +123,7 @@ object MerkleTree {
     val hashes = leafs.map(_.hash)
     val topNode = calcTopNode[D](leafs)
 
-    MerkleTree(topNode, elementsIndex, hashes)
+    MerkleTree(topNode, elementsIndex)
   }
 
   @tailrec

--- a/src/main/scala/scorex/crypto/authds/merkle/MerkleTree.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/MerkleTree.scala
@@ -148,7 +148,6 @@ object MerkleTree {
     val elementsIndex: Map[mutable.WrappedArray.ofByte, Int] = leafs.indices.map { i =>
       (new mutable.WrappedArray.ofByte(leafs(i).hash), i)
     }.toMap
-    val hashes = leafs.map(_.hash)
     val topNode = calcTopNode[D](leafs)
 
     MerkleTree(topNode, elementsIndex)

--- a/src/main/scala/scorex/crypto/hash/CryptographicHash.scala
+++ b/src/main/scala/scorex/crypto/hash/CryptographicHash.scala
@@ -39,7 +39,5 @@ trait CryptographicHash[D <: Digest] {
   def hash(inputs: Array[Byte]*): D = hash(ByteArray.concat(inputs))
 
   def byteArrayToDigest(bytes: Array[Byte]): Try[D]
-
-  def getValue[D <: Digest](x: D): Digest = x
 }
 

--- a/src/main/scala/scorex/crypto/hash/CryptographicHash.scala
+++ b/src/main/scala/scorex/crypto/hash/CryptographicHash.scala
@@ -39,5 +39,7 @@ trait CryptographicHash[D <: Digest] {
   def hash(inputs: Array[Byte]*): D = hash(ByteArray.concat(inputs))
 
   def byteArrayToDigest(bytes: Array[Byte]): Try[D]
+
+  def getValue[D <: Digest](x: D): Digest = x
 }
 

--- a/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
@@ -50,12 +50,13 @@ class MerkleTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyC
   }
 
   property("Batch proof generation by indices") {
+    val r = new Random()
     forAll(smallInt) { N: Int =>
       whenever(N > 0) {
         val d = (0 until N).map(_ => LeafData @@ scorex.utils.Random.randomBytes(LeafSize))
         val tree = MerkleTree(d)
-        val randIndices = (0 until Random.between(1, N + 1))
-          .map(_ => Random.between(0, N))
+        val randIndices = (0 until r.nextInt(N + 1) + 1)
+          .map(_ => r.nextInt(N))
           .distinct
           .sorted
         tree.proofByIndices(randIndices).get.valid(tree.rootHash) shouldBe true

--- a/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
@@ -46,6 +46,17 @@ class MerkleTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyC
     }
   }
 
+  property("Batch proof generation by indexes") {
+    forAll(smallInt) { N: Int =>
+      whenever(N == 7) {
+        val d = (0 until N).map(_ => LeafData @@ scorex.utils.Random.randomBytes(LeafSize))
+        val tree = MerkleTree(d)
+
+        tree.proofByIndexes(Seq(0,1)).get.valid(tree.rootHash, d.map(d => Leaf(d))) shouldBe true
+      }
+    }
+  }
+
   property("Tree creation from 0 elements") {
     val tree = MerkleTree(Seq.empty)(hf)
     tree.rootHash shouldEqual Array.fill(hf.DigestSize)(0: Byte)

--- a/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scorex.crypto.TestingCommons
 import scorex.crypto.authds.LeafData
+import scorex.crypto.authds.merkle.MerkleTree.LeafPrefix
 import scorex.crypto.hash.Keccak256
 
 class MerkleTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers with TestingCommons {
@@ -48,11 +49,12 @@ class MerkleTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyC
 
   property("Batch proof generation by indexes") {
     forAll(smallInt) { N: Int =>
-      whenever(N == 7) {
+      whenever(N == 16) {
         val d = (0 until N).map(_ => LeafData @@ scorex.utils.Random.randomBytes(LeafSize))
         val tree = MerkleTree(d)
-
-        tree.proofByIndexes(Seq(0,1)).get.valid(tree.rootHash, d.map(d => Leaf(d))) shouldBe true
+        val l = Leaf(d.apply(2)).hash
+        val r = Leaf(d.apply(3)).hash
+        tree.proofByIndexes(Seq(2,3,8,13)).get.valid(tree.rootHash) shouldBe true
       }
     }
   }


### PR DESCRIPTION
Hi @kushti, this is the basic implementation of batch merkle proof (compact merkle multiproof) based on [this paper](https://deepai.org/publication/compact-merkle-multiproofs).

While still incomplete, I was hoping to get a few eyes on this to see if I am headed in the right direction.

It seems to traverse the tree correctly when building and validating the proof, but I am still having an issue with the root hash matching during verification.  Also, some of the code is a bit crude and needs to be cleaned up a bit.