### PR TITLE
New features and improvements in sliced authenticated AVL+ trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ resolvers += "Sonatype Releases" at "https://oss.sonatype.org/content/repositori
 
 You can use Scrypto in your sbt project by simply adding the following dependency to your build file:
 ```scala
-libraryDependencies += "org.scorexfoundation" %% "scrypto" % "2.1.6"
+libraryDependencies += "org.scorexfoundation" %% "scrypto" % "2.2.0"
 ```
 
 ### Hash functions

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "23.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "org.whispersystems" % "curve25519-java" % "0.5.0",
-  "org.bouncycastle" % "bcprov-jdk15on" % "1.66",
+  "org.bouncycastle" % "bcprov-jdk15to18" % "1.66",
   "org.scorexfoundation" %% "scorex-util" % "0.1.8"
 )
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,27 @@
+**2.2.0**
+---------
+
+* Rework of sliced AVL+ trees (BatchAVLProverManifest / BatchAVLProverSubtree)
+* Batch Merkle proof implementation
+* AuthenticationTreeOps.logError 
+* Scala, scorex-util, Guava, BouncyCastle dependencies updated
+* example app in SparseMarkleTree reworked into tests (#38)
+* switch from sbt-git to sbt-dynver
+* migration from Travis to GA
+
+
+**2.1.8**
+---------
+
+* Guava's comparator for byte arrays is used instead of custom old one ( #74 )
+* Scala 2.13 support ( #75 )
+
+**2.1.7**
+---------
+
+* remove logback dependency, add sbt-dependency-graph plugin
+* add git versioning, cross-build with scala 2.11, auto sonatype publishing(WIP); remove sbt-lock
+
 **2.1.6**
 ---------
 

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchNode.scala
@@ -11,6 +11,9 @@ sealed trait Node[D <: Digest] extends ToStringHelper {
 
   protected var labelOpt: Option[D] = None
 
+  /**
+    * Get digest of the node. If it was computed previously, read the digest from hash, otherwise, compute it.
+    */
   def label: D = labelOpt match {
     case None =>
       val l = computeLabel

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchNode.scala
@@ -40,7 +40,9 @@ sealed trait InternalNode[D <: Digest] extends Node[D] {
 
   protected val hf: CryptographicHash[D]
 
-  protected def computeLabel: D = hf.hash(Array(InternalNodePrefix, b), left.label, right.label)
+  override protected def computeLabel: D = {
+    hf.hash(Array(InternalNodePrefix, b), left.label, right.label)
+  }
 
   def balance: Balance = b
 
@@ -137,7 +139,9 @@ sealed trait Leaf[D <: Digest] extends Node[D] with KeyInVar {
 
   protected val hf: CryptographicHash[D] // TODO: Seems very wasteful to store hf in every node of the tree, when they are all the same. Is there a better way? Pass them in to label method from above? Same for InternalNode and for other, non-batch, trees
 
-  protected def computeLabel: D = hf.prefixedHash(LeafPrefix, k, v, nk)
+  protected def computeLabel: D = {
+    hf.prefixedHash(LeafPrefix, k, v, nk)
+  }
 
   def getNew(newKey: ADKey = k, newValue: ADValue = v, newNextLeafKey: ADKey = nk): Leaf[D]
 

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/BatchNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/BatchNode.scala
@@ -34,11 +34,13 @@ class LabelOnlyNode[D <: Digest](l: D) extends VerifierNodes[D] {
 }
 
 sealed trait InternalNode[D <: Digest] extends Node[D] {
+  import InternalNode.InternalNodePrefix
+
   protected var b: Balance
 
   protected val hf: CryptographicHash[D]
 
-  protected def computeLabel: D = hf.prefixedHash(1: Byte, Array(b), left.label, right.label)
+  protected def computeLabel: D = hf.hash(Array(InternalNodePrefix, b), left.label, right.label)
 
   def balance: Balance = b
 
@@ -50,6 +52,10 @@ sealed trait InternalNode[D <: Digest] extends Node[D] {
   def getNew(newLeft: Node[D] = left, newRight: Node[D] = right, newBalance: Balance = b): InternalNode[D]
 
   def getNewKey(newKey: ADKey): InternalNode[D]
+}
+
+object InternalNode {
+  val InternalNodePrefix: Byte = 1: Byte
 }
 
 class InternalProverNode[D <: Digest](protected var k: ADKey,
@@ -120,9 +126,10 @@ class InternalVerifierNode[D <: Digest](protected var l: Node[D], protected var 
 }
 
 sealed trait Leaf[D <: Digest] extends Node[D] with KeyInVar {
+  import Leaf.LeafPrefix
+
   protected var nk: ADKey
   protected var v: ADValue
-
 
   def nextLeafKey: ADKey = nk
 
@@ -130,13 +137,18 @@ sealed trait Leaf[D <: Digest] extends Node[D] with KeyInVar {
 
   protected val hf: CryptographicHash[D] // TODO: Seems very wasteful to store hf in every node of the tree, when they are all the same. Is there a better way? Pass them in to label method from above? Same for InternalNode and for other, non-batch, trees
 
-  protected def computeLabel: D = hf.prefixedHash(0: Byte, k, v, nk)
+  protected def computeLabel: D = hf.prefixedHash(LeafPrefix, k, v, nk)
 
   def getNew(newKey: ADKey = k, newValue: ADValue = v, newNextLeafKey: ADKey = nk): Leaf[D]
 
   override def toString: String = {
     s"${arrayToString(label)}: Leaf(${arrayToString(key)}, ${arrayToString(value)}, ${arrayToString(nextLeafKey)})"
   }
+
+}
+
+object Leaf {
+  val LeafPrefix = 0: Byte
 }
 
 class VerifierLeaf[D <: Digest](protected var k: ADKey, protected var v: ADValue, protected var nk: ADKey)

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
@@ -7,6 +7,8 @@ import scorex.crypto.hash.Digest
 /**
   * Top subtree of AVL tree, starting from root node and ending with ProxyInternalNode
   */
-case class BatchAVLProverManifest[D <: Digest](keyLength: Int,
-                                               valueLengthOpt: Option[Int],
-                                               rootAndHeight: (ProverNodes[D], Int))
+case class BatchAVLProverManifest[D <: Digest](rootAndHeight: (ProverNodes[D], Int))
+
+
+//keyLength: Int,
+//valueLengthOpt: Option[Int],

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
@@ -1,15 +1,33 @@
 package scorex.crypto.authds.avltree.batch.serialization
 
-import scorex.crypto.authds.avltree.batch.ProverNodes
+import scorex.crypto.authds.avltree.batch.{InternalProverNode, ProverLeaf, ProverNodes}
 import scorex.crypto.hash.Digest
+
+import scala.collection.mutable
 
 
 /**
   * Top subtree of AVL tree, starting from root node and ending with ProxyInternalNode
   */
-case class BatchAVLProverManifest[D <: Digest](root: ProverNodes[D],
-                                               rootHeight: Int) {
-  def verify: Boolean = {
-    true
+case class BatchAVLProverManifest[D <: Digest](root: ProverNodes[D], rootHeight: Int) {
+
+  def verify(expectedDigest: D): Boolean = {
+    root.label.sameElements(expectedDigest)
   }
+
+  def subtreesIds: mutable.Buffer[D] = {
+    def idCollector(node: ProverNodes[D], acc: mutable.Buffer[D]): mutable.Buffer[D] = {
+      node match {
+        case n: ProxyInternalNode[D] if n.isEmpty =>
+          (acc += n.leftLabel) += n.rightLabel
+        case i : InternalProverNode[D] =>
+          idCollector(i.right, idCollector(i.left, acc))
+        case _: ProverLeaf[D] =>
+          acc
+      }
+    }
+
+    idCollector(root, mutable.Buffer.empty)
+  }
+
 }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
@@ -7,16 +7,27 @@ import scala.collection.mutable
 
 
 /**
-  * Top subtree of AVL tree, starting from root node and ending with ProxyInternalNode
+  * A subtree of AVL tree, which is starting from root node and ending at certain depth with nodes
+  * having no children (ProxyInternalNode). The manifest commits to subtrees below the depth.
   */
 case class BatchAVLProverManifest[D <: Digest](root: ProverNodes[D], rootHeight: Int) {
 
+  /**
+    * Unique (and cryptographically strong) identifier of the manifest (digest of the root node)
+    */
   def id: D = root.label
 
+  /**
+    * Verify that manifest corresponds to expected digest and height provided by a trusted party
+    * (for blockchain protocols, it can be digest and height included by a miner)
+    */
   def verify(expectedDigest: D, expectedHeight: Int): Boolean = {
     id.sameElements(expectedDigest) && expectedHeight == rootHeight
   }
 
+  /**
+    * Identifiers (digests) of subtrees below the manifest
+    */
   def subtreesIds: mutable.Buffer[D] = {
     def idCollector(node: ProverNodes[D], acc: mutable.Buffer[D]): mutable.Buffer[D] = {
       node match {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
@@ -11,8 +11,10 @@ import scala.collection.mutable
   */
 case class BatchAVLProverManifest[D <: Digest](root: ProverNodes[D], rootHeight: Int) {
 
-  def verify(expectedDigest: D): Boolean = {
-    root.label.sameElements(expectedDigest)
+  def id: D = root.label
+
+  def verify(expectedDigest: D, expectedHeight: Int): Boolean = {
+    id.sameElements(expectedDigest) && expectedHeight == rootHeight
   }
 
   def subtreesIds: mutable.Buffer[D] = {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
@@ -7,4 +7,9 @@ import scorex.crypto.hash.Digest
 /**
   * Top subtree of AVL tree, starting from root node and ending with ProxyInternalNode
   */
-case class BatchAVLProverManifest[D <: Digest](rootAndHeight: (ProverNodes[D], Int))
+case class BatchAVLProverManifest[D <: Digest](root: ProverNodes[D],
+                                               rootHeight: Int) {
+  def verify: Boolean = {
+    true
+  }
+}

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverManifest.scala
@@ -8,7 +8,3 @@ import scorex.crypto.hash.Digest
   * Top subtree of AVL tree, starting from root node and ending with ProxyInternalNode
   */
 case class BatchAVLProverManifest[D <: Digest](rootAndHeight: (ProverNodes[D], Int))
-
-
-//keyLength: Int,
-//valueLengthOpt: Option[Int],

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
@@ -13,8 +13,6 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
 
   type SlicedTree = (BatchAVLProverManifest[D], Seq[BatchAVLProverSubtree[D]])
 
-  def slice(tree: BatchAVLProver[D, HF]): SlicedTree = slice(tree, tree.rootNodeHeight / 2)
-
   /**
     * Slice AVL tree to top subtree tree (BatchAVLProverManifest) and
     * bottom subtrees (BatchAVLProverSubtree) with height `subtreeDepth`

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
@@ -31,15 +31,15 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
         currentNode match {
           case n: InternalProverNode[D] if currentHeight > subtreeDepth =>
             val nextParent = ProxyInternalNode(n)
-            parent.mutate(nextParent)
+            parent.setChild(nextParent)
             val leftSubtrees = getSubtrees(n.left, currentHeight - 1, nextParent)
             val rightSubtrees = getSubtrees(n.right, currentHeight - 1, nextParent)
             leftSubtrees ++ rightSubtrees
           case n: InternalProverNode[D] =>
-            parent.mutate(ProxyInternalNode(n))
+            parent.setChild(ProxyInternalNode(n))
             Seq(BatchAVLProverSubtree(n.left), BatchAVLProverSubtree(n.right))
           case l: ProverLeaf[D] =>
-            parent.mutate(l)
+            parent.setChild(l)
             Seq(BatchAVLProverSubtree(l))
         }
       }
@@ -59,12 +59,13 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
               valueLengthOpt: Option[Int]): Try[BatchAVLProver[D, HF]] = Try {
     sliced._1.rootAndHeight._1 match {
       case tn: InternalProverNode[D] =>
+
         def mutateLoop(n: ProverNodes[D]): Unit = n match {
           case n: ProxyInternalNode[D] if n.isEmpty =>
             val left = sliced._2.find(_.subtreeTop.label sameElements n.leftLabel).get.subtreeTop
             val right = sliced._2.find(_.subtreeTop.label sameElements n.rightLabel).get.subtreeTop
-            n.mutate(left)
-            n.mutate(right)
+            n.setChild(left)
+            n.setChild(right)
           case n: InternalProverNode[D] =>
             mutateLoop(n.left)
             mutateLoop(n.right)

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
@@ -134,7 +134,7 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
         val key = ADKey @@ bytes.slice(2, keyLength + 2)
         val leftLabel = hf.byteArrayToDigest(bytes.slice(keyLength + 2, keyLength + 2 + labelLength)).get
         val rightLabel = hf.byteArrayToDigest(bytes.slice(keyLength + 2 + labelLength, keyLength + 2 + 2 * labelLength)).get
-        new ProxyInternalNode[D](key, None, leftLabel, rightLabel, balance)
+        new ProxyInternalNode[D](key, leftLabel, rightLabel, balance)
       case _ =>
         ???
     }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
@@ -96,7 +96,7 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
   def subtreeFromBytes(b: Array[Byte], kl: Int): Try[BatchAVLProverSubtree[D]] = nodesFromBytes(b, kl).
     map(topNode => BatchAVLProverSubtree[D](topNode))
 
-  def nodesToBytes(obj: ProverNodes[D]): Array[Byte] = {
+  def nodesToBytes(rootNode: ProverNodes[D]): Array[Byte] = {
     def loop(currentNode: ProverNodes[D]): Array[Byte] = currentNode match {
       case l: ProverLeaf[D] =>
         Bytes.concat(Array(0.toByte), l.key, l.nextLeafKey, l.value)
@@ -108,7 +108,7 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
         Bytes.concat(Array(1.toByte, n.balance), n.key, Ints.toByteArray(leftBytes.length), leftBytes, rightBytes)
     }
 
-    loop(obj)
+    loop(rootNode)
   }
 
   def nodesFromBytes(bytesIn: Array[Byte], keyLength: Int): Try[ProverNodes[D]] = Try {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
@@ -103,7 +103,7 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
       case l: ProverLeaf[D] =>
         Bytes.concat(Array(0.toByte), l.key, l.nextLeafKey, l.value)
       case n: ProxyInternalNode[D] if n.isEmpty =>
-        Bytes.concat(Array(2.toByte, n.balance), n.key, n.leftLabel, n.rightLabel, n.label)
+        Bytes.concat(Array(2.toByte, n.balance), n.key, n.leftLabel, n.rightLabel)
       case n: InternalProverNode[D] =>
         val leftBytes = loop(n.left)
         val rightBytes = loop(n.right)
@@ -134,8 +134,7 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
         val key = ADKey @@ bytes.slice(2, keyLength + 2)
         val leftLabel = hf.byteArrayToDigest(bytes.slice(keyLength + 2, keyLength + 2 + labelLength)).get
         val rightLabel = hf.byteArrayToDigest(bytes.slice(keyLength + 2 + labelLength, keyLength + 2 + 2 * labelLength)).get
-        val selfLabel = hf.byteArrayToDigest(bytes.slice(keyLength + 2 + 2 * labelLength, keyLength + 2 + 3 * labelLength)).get
-        new ProxyInternalNode[D](key, Some(selfLabel), leftLabel, rightLabel, balance)
+        new ProxyInternalNode[D](key, None, leftLabel, rightLabel, balance)
       case _ =>
         ???
     }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSerializer.scala
@@ -60,8 +60,8 @@ class BatchAVLProverSerializer[D <: Digest, HF <: CryptographicHash[D]](implicit
 
         def mutateLoop(n: ProverNodes[D]): Unit = n match {
           case n: ProxyInternalNode[D] if n.isEmpty =>
-            val left = sliced._2.find(_.subtreeTop.label sameElements n.leftLabel).get.subtreeTop
-            val right = sliced._2.find(_.subtreeTop.label sameElements n.rightLabel).get.subtreeTop
+            val left = sliced._2.find(_.id sameElements n.leftLabel).get.subtreeTop
+            val right = sliced._2.find(_.id sameElements n.rightLabel).get.subtreeTop
             n.setChild(left)
             n.setChild(right)
           case n: InternalProverNode[D] =>

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
@@ -1,7 +1,10 @@
 package scorex.crypto.authds.avltree.batch.serialization
 
-import scorex.crypto.authds.avltree.batch.ProverNodes
+import scorex.crypto.authds.ADValue
+import scorex.crypto.authds.avltree.batch.{InternalProverNode, ProverLeaf, ProverNodes}
 import scorex.crypto.hash.Digest
+
+import scala.collection.mutable
 
 /**
   * AVL subtree, starting from manifest's terminal internal nodes and ending with Leafs
@@ -14,6 +17,19 @@ case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D]) {
 
   def verify(expectedDigest: D): Boolean = {
     subtreeTop.label.sameElements(expectedDigest)
+  }
+
+  def leafValues: mutable.Buffer[ADValue] = {
+    def idCollector(node: ProverNodes[D], acc: mutable.Buffer[ADValue]): mutable.Buffer[ADValue] = {
+      node match {
+        case i : InternalProverNode[D] =>
+          idCollector(i.right, idCollector(i.left, acc))
+        case l: ProverLeaf[D] =>
+          acc += l.value
+      }
+    }
+
+    idCollector(subtreeTop, mutable.Buffer.empty)
   }
 
 }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
@@ -4,6 +4,6 @@ import scorex.crypto.authds.avltree.batch.ProverNodes
 import scorex.crypto.hash.Digest
 
 /**
-  * AVL subtree, starting from Manifests FinalInternalNode and ending with Leafs
+  * AVL subtree, starting from manifest's terminal internal nodes and ending with Leafs
   */
 case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D])

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
@@ -6,4 +6,9 @@ import scorex.crypto.hash.Digest
 /**
   * AVL subtree, starting from manifest's terminal internal nodes and ending with Leafs
   */
-case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D])
+case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D]) {
+  /**
+    * Unique (and cryptographically strong) identifier of the sub-tree
+    */
+  def id: D = subtreeTop.label
+}

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
@@ -7,7 +7,7 @@ import scorex.crypto.hash.Digest
 import scala.collection.mutable
 
 /**
-  * AVL subtree, starting from manifest's terminal internal nodes and ending with Leafs
+  * AVL subtree, starting from a manifest's terminal internal node and ending with Leafs
   */
 case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D]) {
   /**
@@ -15,10 +15,16 @@ case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D]) {
     */
   def id: D = subtreeTop.label
 
+  /**
+    * Verify that manifest corresponds to expected digest (e.g. got from a manifest)
+    */
   def verify(expectedDigest: D): Boolean = {
     subtreeTop.label.sameElements(expectedDigest)
   }
 
+  /**
+    * @return leafs of the subtree
+    */
   def leafValues: mutable.Buffer[ADValue] = {
     def idCollector(node: ProverNodes[D], acc: mutable.Buffer[ADValue]): mutable.Buffer[ADValue] = {
       node match {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
@@ -12,6 +12,8 @@ case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D]) {
     */
   def id: D = subtreeTop.label
 
-  def verify: Boolean = true
+  def verify(expectedDigest: D): Boolean = {
+    subtreeTop.label.sameElements(expectedDigest)
+  }
 
 }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/BatchAVLProverSubtree.scala
@@ -11,4 +11,7 @@ case class BatchAVLProverSubtree[D <: Digest](subtreeTop: ProverNodes[D]) {
     * Unique (and cryptographically strong) identifier of the sub-tree
     */
   def id: D = subtreeTop.label
+
+  def verify: Boolean = true
+
 }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -20,12 +20,17 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
     hf.hash(Array(InternalNodePrefix, b), leftLabel, rightLabel)
   }
 
-  override def label: D = if (isEmpty) {
-    val l = selfLabelOpt.getOrElse(computeLabel)
-    labelOpt = Some(l)
-    l
-  } else {
-    super.label
+  /**
+    * Get digest of the node. If it was computed previously, read the digest from hash, otherwise,
+    * take externally provided label or compute if not provided.
+    */
+  override def label: D = labelOpt match {
+    case Some(l) =>
+      l
+    case None =>
+      val l = selfLabelOpt.getOrElse(computeLabel)
+      labelOpt = Some(l)
+      l
   }
 
   private[serialization] def setChild(n: ProverNodes[D]): Unit = {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -16,7 +16,7 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
 
   override def label: D = if (isEmpty) selfLabelOpt.getOrElse(computeLabel) else super.label
 
-  def mutate(n: ProverNodes[D]): Unit = {
+  def setChild(n: ProverNodes[D]): Unit = {
     if (n.label sameElements leftLabel) {
       l = n
     } else if (n.label sameElements rightLabel) {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -9,7 +9,6 @@ import scorex.crypto.hash.{CryptographicHash, Digest}
   * Internal node for which not children are stored but just their digests
   */
 class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
-                                     val selfLabelOpt: Option[D],
                                      val leftLabel: D,
                                      val rightLabel: D,
                                      protected var pb: Balance)
@@ -18,19 +17,6 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
 
   override def computeLabel: D = {
     hf.hash(Array(InternalNodePrefix, b), leftLabel, rightLabel)
-  }
-
-  /**
-    * Get digest of the node. If it was computed previously, read the digest from hash, otherwise,
-    * take externally provided label or compute if not provided.
-    */
-  override def label: D = labelOpt match {
-    case Some(l) =>
-      l
-    case None =>
-      val l = selfLabelOpt.getOrElse(computeLabel)
-      labelOpt = Some(l)
-      l
   }
 
   private[serialization] def setChild(n: ProverNodes[D]): Unit = {
@@ -53,6 +39,6 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
 
 object ProxyInternalNode {
   def apply[D <: Digest](node: InternalProverNode[D])(implicit phf: CryptographicHash[D]): ProxyInternalNode[D] = {
-    new ProxyInternalNode[D](node.key, Some(node.label), node.left.label, node.right.label, node.balance)
+    new ProxyInternalNode[D](node.key, node.left.label, node.right.label, node.balance)
   }
 }

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -28,7 +28,10 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
 
   def isEmpty: Boolean = l == null || r == null
 
-  override def toString: String = s"${arrayToString(label)} ProxyInternalNode($isEmpty,${arrayToString(pk)},${arrayToString(leftLabel)}|${l == null},${arrayToString(rightLabel)}}|${r == null},$pb})"
+  override def toString: String = {
+    s"${arrayToString(label)} ProxyInternalNode($isEmpty,${arrayToString(pk)},${arrayToString(leftLabel)}|${l == null},${arrayToString(rightLabel)}}|${r == null},$pb})"
+  }
+
 }
 
 object ProxyInternalNode {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -13,9 +13,17 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
                                     (implicit val phf: CryptographicHash[D])
   extends InternalProverNode(k = pk, l = null, r = null, b = pb)(phf) {
 
-  override def computeLabel: D = hf.hash(Array(InternalNodePrefix, b), leftLabel, rightLabel)
+  override def computeLabel: D = {
+    hf.hash(Array(InternalNodePrefix, b), leftLabel, rightLabel)
+  }
 
-  override def label: D = if (isEmpty) selfLabelOpt.getOrElse(computeLabel) else super.label
+  override def label: D = if (isEmpty) {
+    val l = selfLabelOpt.getOrElse(computeLabel)
+    labelOpt = Some(l)
+    l
+  } else {
+    super.label
+  }
 
   def setChild(n: ProverNodes[D]): Unit = {
     if (n.label sameElements leftLabel) {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -5,6 +5,9 @@ import scorex.crypto.authds.avltree.batch.{InternalProverNode, ProverNodes}
 import scorex.crypto.authds.{ADKey, Balance}
 import scorex.crypto.hash.{CryptographicHash, Digest}
 
+/**
+  * Internal node for which not children are stored but just their digests
+  */
 class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
                                      val selfLabelOpt: Option[D],
                                      val leftLabel: D,
@@ -25,7 +28,7 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
     super.label
   }
 
-  def setChild(n: ProverNodes[D]): Unit = {
+  private[serialization] def setChild(n: ProverNodes[D]): Unit = {
     if (n.label sameElements leftLabel) {
       l = n
     } else if (n.label sameElements rightLabel) {

--- a/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
+++ b/src/main/scala/scorex/crypto/authds/avltree/batch/serialization/ProxyInternalNode.scala
@@ -1,5 +1,6 @@
 package scorex.crypto.authds.avltree.batch.serialization
 
+import scorex.crypto.authds.avltree.batch.InternalNode.InternalNodePrefix
 import scorex.crypto.authds.avltree.batch.{InternalProverNode, ProverNodes}
 import scorex.crypto.authds.{ADKey, Balance}
 import scorex.crypto.hash.{CryptographicHash, Digest}
@@ -12,7 +13,7 @@ class ProxyInternalNode[D <: Digest](protected var pk: ADKey,
                                     (implicit val phf: CryptographicHash[D])
   extends InternalProverNode(k = pk, l = null, r = null, b = pb)(phf) {
 
-  override def computeLabel: D = hf.prefixedHash(1: Byte, Array(b), leftLabel, rightLabel)
+  override def computeLabel: D = hf.hash(Array(InternalNodePrefix, b), leftLabel, rightLabel)
 
   override def label: D = if (isEmpty) selfLabelOpt.getOrElse(computeLabel) else super.label
 

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
@@ -114,6 +114,26 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
     serializer.manifestFromBytes(manifestBytes, tree.keyLength).isFailure shouldBe true
   }
 
+  property("verify manifest") {
+    val tree = generateProver()
+    val sliced = slice(tree)
+    val manifest = sliced._1
+    manifest.verify(tree.topNode.label) shouldBe true
+  }
+
+  property("subtreesIds for manifest") {
+    val tree = generateProver()
+    val sliced = slice(tree)
+    val manifest = sliced._1
+    val subtrees = sliced._2
+
+    val manSubtrees = manifest.subtreesIds
+    manSubtrees.size shouldBe subtrees.size
+    manSubtrees.foreach{digest =>
+      subtrees.exists(_.id.sameElements(digest)) shouldBe true
+    }
+  }
+
   def leftTree(n: ProverNodes[D]): Seq[ProverNodes[D]] = n match {
     case n: ProxyInternalNode[D] if n.isEmpty =>
       Seq(n)

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
@@ -24,6 +24,10 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
 
   def randomValue(size: Int = 64): ADValue = ADValue @@ Random.randomBytes(size)
 
+  val serializer = new BatchAVLProverSerializer[D, HF]
+
+  def slice(tree: BatchAVLProver[D, HF]) = serializer.slice(tree, tree.rootNodeHeight / 2)
+
   private def generateProver(size: Int = InitialTreeSize): BatchAVLProver[D, HF] = {
     val prover = new BatchAVLProver[D, HF](KL, None)
     val keyValues = (0 until size) map { i =>
@@ -40,8 +44,7 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
         val tree = generateProver(treeSize)
         val height = tree.rootNodeHeight
         val digest = tree.digest
-        val serializer = new BatchAVLProverSerializer[D, HF]
-        val sliced = serializer.slice(tree)
+        val sliced = slice(tree)
 
         val manifestLeftTree = leftTree(sliced._1.rootAndHeight._1)
         val subtreeLeftTree = leftTree(sliced._2.head.subtreeTop)
@@ -63,7 +66,7 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
       val kl = tree.keyLength
       val digest = tree.digest
 
-      val sliced = serializer.slice(tree)
+      val sliced = slice(tree)
 
       val manifestBytes = serializer.manifestToBytes(sliced._1)
       val subtreeBytes = sliced._2.map(t => serializer.subtreeToBytes(t))
@@ -87,7 +90,7 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
       val tree = generateProver(treeSize)
       val kl = tree.keyLength
       val digest = tree.digest
-      val sliced = serializer.slice(tree)
+      val sliced = slice(tree)
 
       val manifest = sliced._1
       val manifestBytes = serializer.manifestToBytes(manifest)
@@ -99,8 +102,8 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
 
   property("wrong manifest") {
     val tree = generateProver()
-    val serializer = new BatchAVLProverSerializer[D, HF]
-    val sliced = serializer.slice(tree)
+    println("h: " + tree.rootNodeHeight)
+    val sliced = slice(tree)
     val manifest = sliced._1
     val wrongManifest: BatchAVLProverManifest[D] =
       BatchAVLProverManifest(manifest.rootAndHeight._1 -> (manifest.rootAndHeight._2 + 1))

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
@@ -105,10 +105,12 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
     println("h: " + tree.rootNodeHeight)
     val sliced = slice(tree)
     val manifest = sliced._1
+    println("manifest: " + manifest)
     val wrongManifest: BatchAVLProverManifest[D] =
       BatchAVLProverManifest(manifest.rootAndHeight._1 -> (manifest.rootAndHeight._2 + 1))
 
     val manifestBytes = serializer.manifestToBytes(wrongManifest)
+    println("mb: " + manifestBytes.size)
     serializer.manifestFromBytes(manifestBytes, tree.keyLength).isFailure shouldBe true
   }
 

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
@@ -107,11 +107,9 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
     val manifestBytes = serializer.manifestToBytes(manifest)
     val idx = manifestBytes.indexOfSlice(subtreeId)
     manifestBytes(idx) = ((manifestBytes(idx) + 1) % Byte.MaxValue).toByte
+    val wrongManifest = serializer.manifestFromBytes(manifestBytes, tree.keyLength).get
 
-    // whether manifest deserialization or follow-up verification must fail
-    serializer.manifestFromBytes(manifestBytes, tree.keyLength)
-      .get
-      .verify(manifest.id, manifest.rootHeight) shouldBe false
+    wrongManifest.verify(manifest.root.label, manifest.rootHeight) shouldBe false
 
     val subtree = sliced._2.head
     val subtreeBytes = serializer.subtreeToBytes(subtree)

--- a/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/avltree/batch/serialization/AVLBatchSerializationSpecification.scala
@@ -46,7 +46,7 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
         val digest = tree.digest
         val sliced = slice(tree)
 
-        val manifestLeftTree = leftTree(sliced._1.rootAndHeight._1)
+        val manifestLeftTree = leftTree(sliced._1.root)
         val subtreeLeftTree = leftTree(sliced._2.head.subtreeTop)
 
         manifestLeftTree.length should be < height
@@ -96,7 +96,7 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
       val manifestBytes = serializer.manifestToBytes(manifest)
       val deserializedManifest = serializer.manifestFromBytes(manifestBytes, kl).get
 
-      deserializedManifest.rootAndHeight._1.label shouldBe manifest.rootAndHeight._1.label
+      deserializedManifest.root.label shouldBe manifest.root.label
     }
   }
 
@@ -107,7 +107,7 @@ class AVLBatchSerializationSpecification extends AnyPropSpec with ScalaCheckDriv
     val manifest = sliced._1
     println("manifest: " + manifest)
     val wrongManifest: BatchAVLProverManifest[D] =
-      BatchAVLProverManifest(manifest.rootAndHeight._1 -> (manifest.rootAndHeight._2 + 1))
+      BatchAVLProverManifest(manifest.root, manifest.rootHeight + 1)
 
     val manifestBytes = serializer.manifestToBytes(wrongManifest)
     println("mb: " + manifestBytes.size)


### PR DESCRIPTION
In this PR:

* BatchAVLProverManifest reworked (key and value length removed, to be provided externally and not stored)
* new methods in BatchAVLProverManifest (to verify integrity and get subtree digests)
* new methods in BatchAVLProverSubtree (to verify integrity and get subtree leafs)
* no label of self is serialized for ProxyInternalNode (it is better to recalculate it after deserialization, to avoid malicious modifications on the way) 
* def slice() with default depth moved from BatchAVLProverSerializer to tests 
* magic hash prefixes(0,1) replaced with named constants LeafPrefix / InternalNodePrefix
