### PR TITLE
Batch Merkle Proof - override equals for matcher array equality

### DIFF
--- a/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
@@ -91,17 +91,31 @@ case class BatchMerkleProof[D <: Digest](indices: Seq[(Int, Digest)], proofs: Se
     }
 
     val e = indices sortBy(_._1)
-    loop(indices.map(_._1), e, proofs).head.sameElements(expectedRootHash)
+    loop(indices.map(_._1), e, proofs) match {
+      case root: Seq[Digest] if root.size == 1 => root.head.sameElements(expectedRootHash)
+      case _ => false
+    }
   }
 
     override def equals(obj: Any): Boolean = obj match {
       case that: BatchMerkleProof[D] =>
-        (this.indices zip that.indices forall { case (left, right) =>
-          left._1 == right._1 && util.Arrays.equals(left._2, right._2)
-        }) &&
-          (this.proofs zip that.proofs forall { case (left, right) =>
-            util.Arrays.equals(left._1, right._1) && left._2 == right._2
-          })
+        if (this.indices.size != that.indices.size ||
+          this.proofs.size != that.proofs.size) {
+          return false
+        }
+        for (i <- this.indices.indices) {
+          if (this.indices.apply(i)._1 != that.indices.apply(i)._1 ||
+            !util.Arrays.equals(this.indices.apply(i)._2, that.indices.apply(i)._2)) {
+            return false
+          }
+        }
+        for (i <- this.proofs.indices) {
+          if (this.proofs.apply(i)._2 != that.proofs.apply(i)._2 ||
+            !util.Arrays.equals(this.proofs.apply(i)._1, that.proofs.apply(i)._1)) {
+            return false
+          }
+        }
+        true
       case _ => false
     }
 }

--- a/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/BatchMerkleProof.scala
@@ -5,6 +5,7 @@ import scorex.crypto.authds.merkle.MerkleTree.InternalNodePrefix
 import scorex.crypto.hash.{CryptographicHash, Digest}
 import scorex.util.ScorexEncoding
 
+import java.util
 import scala.language.postfixOps
 
   /**
@@ -92,4 +93,15 @@ case class BatchMerkleProof[D <: Digest](indices: Seq[(Int, Digest)], proofs: Se
     val e = indices sortBy(_._1)
     loop(indices.map(_._1), e, proofs).head.sameElements(expectedRootHash)
   }
+
+    override def equals(obj: Any): Boolean = obj match {
+      case that: BatchMerkleProof[D] =>
+        (this.indices zip that.indices forall { case (left, right) =>
+          left._1 == right._1 && util.Arrays.equals(left._2, right._2)
+        }) &&
+          (this.proofs zip that.proofs forall { case (left, right) =>
+            util.Arrays.equals(left._1, right._1) && left._2 == right._2
+          })
+      case _ => false
+    }
 }

--- a/src/main/scala/scorex/crypto/authds/merkle/MerkleTree.scala
+++ b/src/main/scala/scorex/crypto/authds/merkle/MerkleTree.scala
@@ -95,7 +95,7 @@ case class MerkleTree[D <: Digest](topNode: Node[D],
       m
     }
 
-    if (indices.forall(index => index >= 0 && index < length)) {
+    if (indices.nonEmpty && indices.forall(index => index >= 0 && index < length)) {
       val hashes: Seq[Digest] = elementsHashIndex.toSeq.sortBy(_._2).map(_._1.toArray.asInstanceOf[Digest])
       val normalized_indices = indices.distinct.sorted
       val multiproof = loop(normalized_indices, hashes)

--- a/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
+++ b/src/test/scala/scorex/crypto/authds/merkle/MerkleTreeSpecification.scala
@@ -82,6 +82,12 @@ class MerkleTreeSpecification extends AnyPropSpec with ScalaCheckDrivenPropertyC
     tree.proofByIndices(Seq(2,10)) shouldBe None
   }
 
+  property("Empty Batch proof generation should be None") {
+    val d = (0 until 10).map(_ => LeafData @@ scorex.utils.Random.randomBytes(LeafSize))
+    val tree = MerkleTree(d)
+    tree.proofByIndices(Seq.empty[Int]) shouldBe None
+  }
+
   property("Tree creation from 0 elements") {
     val tree = MerkleTree(Seq.empty)(hf)
     tree.rootHash shouldEqual Array.fill(hf.DigestSize)(0: Byte)


### PR DESCRIPTION
Required for https://github.com/ergoplatform/ergo/pull/1526

ScalaTest matchers do not properly evaluate `Array` contents as per https://github.com/scalatest/scalatest/issues/491.
Even when defining a custom `Equality[BatchMerkleProof]` trait, it does not get invoked when the target object is wrapped inside another container.  This was causing problems in the Ergo Node PoPow serialization tests,

As we are not using `BatchMerkleProof` inside any hash-based collections, I think we can avoid overriding hashcode as well?

Open to any alternative suggestions.